### PR TITLE
Disabling the black-hole absorption of the forward magnet due to bug in blackhole handling of `BeamLineMagnetSubsystem`

### DIFF
--- a/common/G4_hFarFwdBeamLine_EIC.C
+++ b/common/G4_hFarFwdBeamLine_EIC.C
@@ -165,7 +165,7 @@ void hFarFwdDefineMagnets(PHG4Reco* g4Reco){
 		      bl->set_double_param("inner_radius",inner_radius_zin);
 		      bl->set_double_param("outer_radius", outer_magnet_diameter/2.);
 		      bl->SetActive(magnet_active);
-		      bl->BlackHole();
+		      // bl->BlackHole(); disabling the black-hole absorbtion of the forward magnet due to bug in blackhole handling of `BeamLineMagnetSubsystem`
 		      if (absorberactive)  
 			{
 			  bl->SetAbsorberActive();


### PR DESCRIPTION
As discussed in https://chat.sdcc.bnl.gov/ecce/pl/quc9bd9h8jy4zj635onn5yiyne there is a bug in `BeamLineMagnetSubsystem` for handling blackhole vol. Disabling the black-hole absorption of the forward magnet for now, until the bug in blackhole handling of `BeamLineMagnetSubsystem` is fixed. 