### PR TITLE
Small u[dates to default macro

### DIFF
--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -20,6 +20,7 @@
 #include <fun4all/Fun4AllServer.h>
 
 #include <phool/recoConsts.h>
+#include <g4eval/EventEvaluator.h>
 
 R__LOAD_LIBRARY(libfun4all.so)
 
@@ -46,6 +47,9 @@ int Fun4All_G4_EICDetector(
   // if the RANDOMSEED flag is set its value is taken as initial seed
   // which will produce identical results so you can debug your code
   // rc->set_IntFlag("RANDOMSEED", 12345);
+
+  // Enabling the event evaluator?
+  bool use_event_evaluator = true;
 
   //===============
   // Input options
@@ -210,6 +214,7 @@ int Fun4All_G4_EICDetector(
   if (Input::READEIC)
   {
     //! apply EIC beam parameter following EIC CDR
+    INPUTGENERATOR::EICFileReader->SetFirstEntry(skip);
     Input::ApplyEICBeamParameter(INPUTGENERATOR::EICFileReader);
   }
 
@@ -464,6 +469,33 @@ int Fun4All_G4_EICDetector(
   //----------------------
   // Simulation evaluation
   //----------------------
+  if (use_event_evaluator)
+  {
+    EventEvaluator *eval = new EventEvaluator("EVENTEVALUATOR",  outputroot + "_eventtree.root");
+    eval->set_reco_tracing_energy_threshold(0.05);
+    eval->Verbosity(0);
+
+    if (Enable::TRACKING_EVAL)
+    {
+      eval->set_do_TRACKS(true);
+      eval->set_do_HITS(true);  
+      eval->set_do_PROJECTIONS(true);
+      if (G4TRACKING::DISPLACED_VERTEX) 
+        eval->set_do_VERTEX(true);
+     }
+    if (Enable::CEMC_EVAL) eval->set_do_CEMC(true); 
+    if (Enable::EEMC_EVAL) eval->set_do_EEMC(true);
+    if (Enable::FEMC_EVAL) eval->set_do_FEMC(true); 
+    if (Enable::HCALIN_EVAL) eval->set_do_HCALIN(true);
+    if (Enable::HCALOUT_EVAL) eval->set_do_HCALOUT(true);
+    if (Enable::FHCAL_EVAL) eval->set_do_FHCAL(true);
+    if (Enable::FHCAL_EVAL || Enable::FEMC_EVAL || Enable::EEMC_EVAL)  
+       eval->set_do_CLUSTERS(true);
+    
+    eval->set_do_MCPARTICLES(true);  
+    se->registerSubsystem(eval);
+  }
+
   if (Enable::TRACKING_EVAL) Tracking_Eval(outputroot + "_g4tracking_eval.root");
 
   if (Enable::CEMC_EVAL) CEMC_Eval(outputroot + "_g4cemc_eval.root");


### PR DESCRIPTION
Added in the skip ability for EIC-smeared TTrees

Updated the event evaluator enable. There is now a top booloean flag and everything is contained within the statement so we can globally turn the EventEval or individual evaluators on/off