### PR TITLE
Enable calorimeter projections by default

### DIFF
--- a/common/G4_Tracking_EIC.C
+++ b/common/G4_Tracking_EIC.C
@@ -282,6 +282,37 @@ void Tracking_Eval(const std::string &outputfile)
   fast_sim_eval->set_trackmapname(TRACKING::TrackNodeName);
   fast_sim_eval->set_filename(outputfile);
   fast_sim_eval->Verbosity(verbosity);
+  //-------------------------
+  // FEMC
+  //-------------------------
+  // Saved track states (projections)
+  if (Enable::FEMC && G4TRACKING::PROJECTION_FEMC)
+  {
+    fast_sim_eval->AddProjection("FEMC");
+  }
+
+  //-------------------------
+  // FHCAL
+  //-------------------------
+  if (Enable::FHCAL && G4TRACKING::PROJECTION_FHCAL)
+  {
+    fast_sim_eval->AddProjection("FHCAL");
+  }
+  //-------------------------
+  // CEMC
+  //-------------------------
+  if (Enable::CEMC && G4TRACKING::PROJECTION_CEMC)
+  {
+    fast_sim_eval->AddProjection("CEMC");
+  }
+  //-------------------------
+  // EEMC
+  //-------------------------
+  if (Enable::EEMC && G4TRACKING::PROJECTION_EEMC)
+  {
+    fast_sim_eval->AddProjection("EEMC");
+  }
+
   se->registerSubsystem(fast_sim_eval);
 }
 #endif

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -276,10 +276,10 @@ int Fun4All_G4_EICDetector(
   Enable::TRACKING_EVAL = Enable::TRACKING && true;
   G4TRACKING::DISPLACED_VERTEX = false;  // this option exclude vertex in the track fitting and use RAVE to reconstruct primary and 2ndary vertexes
                                          // projections to calorimeters
-  G4TRACKING::PROJECTION_EEMC = false;
-  G4TRACKING::PROJECTION_CEMC = false;
-  G4TRACKING::PROJECTION_FEMC = false;
-  G4TRACKING::PROJECTION_FHCAL = false;
+  G4TRACKING::PROJECTION_EEMC = true;
+  G4TRACKING::PROJECTION_CEMC = true;
+  G4TRACKING::PROJECTION_FEMC = true;
+  G4TRACKING::PROJECTION_FHCAL = true;
 
   Enable::CEMC = true;
   //  Enable::CEMC_ABSORBER = true;


### PR DESCRIPTION
Enabling the calorimeter projections by default following discussions at https://chat.sdcc.bnl.gov/ecce/pl/7hgkng88dbdqtfrh76dw5nmi8h 

Example output on the eval output for a track projection to CEMC
```
root G4EICDetector_g4tracking_eval.root
root [1] tracks->Show(1)
======> EVENT:1
 event           = 1
 gtrackID        = 2
 gflavor         = -211
 gpx             = -9.25795
 gpy             = -7.38249
 gpz             = 8.15291
 gvx             = 0
 gvy             = 0
 gvz             = -0.42091
 gvt             = 0
// track projections
 CEMC_proj_x     = -73.4557
 CEMC_proj_y     = -60.6291
 CEMC_proj_z     = 65.166
 CEMC_proj_path_length = 115.631
 CEMC_proj_px    = -8.8414
 CEMC_proj_py    = -7.55757
 CEMC_proj_pz    = 8.01038
// G4 truth values
 CEMC_x          = -82.1701
 CEMC_y          = -68.1566
 CEMC_z          = 73.0675
 CEMC_t          = 4.32361
 CEMC_px         = -8.73653
 CEMC_py         = -7.64965
 CEMC_pz         = 8.01466
```

Pending a bug fix in https://github.com/sPHENIX-Collaboration/coresoftware/pull/1191 to merge