### PR TITLE
 Addition of new ZDC detector in far forward

### DIFF
--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -48,6 +48,10 @@ int Fun4All_G4_EICDetector(
   // which will produce identical results so you can debug your code
   // rc->set_IntFlag("RANDOMSEED", 12345);
 
+  // Use the event evaluator or the default detector evaluators
+  bool use_event_evaluator = true;
+  bool use_individual_evaluators = true;
+
   //===============
   // Input options
   //===============

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -48,10 +48,6 @@ int Fun4All_G4_EICDetector(
   // which will produce identical results so you can debug your code
   // rc->set_IntFlag("RANDOMSEED", 12345);
 
-  // Use the event evaluator or the default detector evaluators
-  bool use_event_evaluator = true;
-  bool use_individual_evaluators = true;
-
   //===============
   // Input options
   //===============
@@ -242,7 +238,7 @@ int Fun4All_G4_EICDetector(
   //======================
   // Global options (enabled for all subsystems - if implemented)
   //  Enable::ABSORBER = true;
-  //  Enable::OVERLAPCHECK = true;
+    Enable::OVERLAPCHECK = true;
   //  Enable::VERBOSITY = 1;
 
   //  Enable::BBC = true;

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -238,7 +238,7 @@ int Fun4All_G4_EICDetector(
   //======================
   // Global options (enabled for all subsystems - if implemented)
   //  Enable::ABSORBER = true;
-    Enable::OVERLAPCHECK = true;
+  //  Enable::OVERLAPCHECK = true;
   //  Enable::VERBOSITY = 1;
 
   //  Enable::BBC = true;


### PR DESCRIPTION
!!!Do not merge until 2021/06/09 so the new ZDC class is in our daily build!!!

The new ZDC detector has been added to our macros to coincide with the new ZDC class

The ZDC surrogate is still enabled with its blackhole. The new ZDC sits behind this blackhole and so does nothing by default. You can disable the blackhole in your macro with:

Enable::ZDC_DISABLE_BLACKHOLE = true;