### PR TITLE
Added mRICH macro

### DIFF
--- a/common/G4_mRICH.C
+++ b/common/G4_mRICH.C
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "GlobalVariables.C"
+
+#include <g4main/PHG4Reco.h>
+
+#include <g4mrich/PHG4mRICHSubsystem.h>
+//#include <g4rich/PHG4mRICHSubsystem.h>
+/*!
+ * \file G4_mRICH.C
+ * \brief Aerogel mRICH for EIC detector
+ * \author Murad Sarsour
+ * \date $Date: 2020/7/2  $
+ */
+
+namespace Enable
+{
+  bool mRICH = false;
+  bool mRICH_OVERLAPCHECK = false;
+}
+
+void
+mRICHInit()
+{
+
+}
+
+//-1: single module
+// 0: build h-side sectors and e-side wall
+// 1: build h-side sectors
+// 2: build e-side wall
+// 3: build h-side wall
+// 4: build h-side wall and e-side wall
+// 5: build b-side sectors
+// 6: build projected e-side wall
+
+void
+mRICHSetup(PHG4Reco* g4Reco, const int detectorSetup = 1, //1: full setup; 0:skeleton 
+	   const int mRICHsystemSetup = 6//5//2//-1//
+	   )
+{
+
+  bool OverlapCheck = Enable::OVERLAPCHECK || Enable::mRICH_OVERLAPCHECK;
+
+  PHG4mRICHSubsystem *mRICH = new PHG4mRICHSubsystem("mRICH",1);
+  mRICH->set_int_param("detectorSetup",detectorSetup);
+  mRICH->set_int_param("subsystemSetup",mRICHsystemSetup);
+  mRICH->UseCalibFiles(PHG4DetectorSubsystem::xml);
+  mRICH->SetCalibrationFileDir(string(getenv("CALIBRATIONROOT")) + string("/mRICH/Geometry/") );
+  mRICH->OverlapCheck(OverlapCheck);
+
+  g4Reco->registerSubsystem(mRICH);
+}
+
+void mRICH_Eval(std::string outputfile, int verbosity = 0) {
+
+  gSystem->Load("libfun4all.so");
+  gSystem->Load("libg4eval.so");
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  return;
+}

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -306,6 +306,7 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - 'hadron' direction
   Enable::RICH = true;
+  Enable::mRICH = true; //-m/s- added mRICH
   Enable::AEROGEL = true;
 
   Enable::FEMC = true;

--- a/detectors/EICDetector/G4Setup_EICDetector.C
+++ b/detectors/EICDetector/G4Setup_EICDetector.C
@@ -27,6 +27,7 @@
 #include <G4_User.C>
 #include <G4_World.C>
 #include <G4_hFarFwdBeamLine_EIC.C>
+#include <G4_mRICH.C>
 
 #include <g4detectors/PHG4CylinderSubsystem.h>
 
@@ -98,6 +99,7 @@ void G4Init()
   if (Enable::EEMC) EEMCInit();
   if (Enable::DIRC) DIRCInit();
   if (Enable::RICH) RICHInit();
+  if (Enable::mRICH) mRICHInit();
   if (Enable::AEROGEL) AerogelInit();
   if (Enable::USER) UserInit();
   if (Enable::BLACKHOLE) BlackHoleInit();
@@ -174,6 +176,7 @@ int G4Setup()
 
   if (Enable::DIRC) DIRCSetup(g4Reco);
   if (Enable::RICH) RICHSetup(g4Reco);
+  if (Enable::mRICH) mRICHSetup(g4Reco);
   if (Enable::AEROGEL) AerogelSetup(g4Reco);
 
   //----------------------------------------


### PR DESCRIPTION
This adds the mRICH to our detector simulation. We should hold off merging until this appears in our daily build. 

There are overlaps with the xtal calo but we will fix this when we have all the detectors in place

eicdetector PR: https://github.com/eic/fun4all_eicdetectors/pull/16
eiccalibration PR: https://github.com/ECCE-EIC/fun4all_eiccalibrations/pull/1 