### PR TITLE
updated inner HCAL design for ECCE first simulation campaign

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -88,6 +88,8 @@ void HCalInnerInit(const int iflag = 0)
   if (iflag == 1)
   {
     G4HCALIN::inner_hcal_eic = 1;
+    // ECCE version is stainless steel
+    G4HCALIN::inner_hcal_material_Al = false;
   }
 }
 
@@ -119,6 +121,20 @@ double HCalInner(PHG4Reco *g4Reco,
     }
     hcal->set_string_param("material", "SS310");
   }
+
+  // ECCE Inner HCAL paremeters
+  // First pass - JGL - 06/14/2021
+  // adjust inner radius to make the inner HCAL less deep, 
+  // but keep the tilt angle and tiles the same shape. 
+  // NOTES: 
+  // (1) Inner and Outer radii from Sketchup, but very likely too
+  //     close to cryostat. 
+
+  hcal->set_double_param("outer_radius", 138.5);
+  hcal->set_double_param("scinti_outer_radius", 138.0);
+  hcal->set_double_param("inner_radius", 134.0);
+  hcal->set_double_param("tilt_angle", 36.15);
+
   // hcal->set_double_param("inner_radius", 117.27);
   //-----------------------------------------
   // the light correction can be set in a single call

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -306,7 +306,7 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - 'hadron' direction
   Enable::RICH = true;
-  Enable::mRICH = true; //-m/s- added mRICH
+  Enable::mRICH = false;
   Enable::AEROGEL = true;
 
   Enable::FEMC = true;


### PR DESCRIPTION
This is a modified G4_HcalIn_ref.C for the first ECCE simulation campaign.  It makes use of the design of the sPHENIX inner HCAL, modified to act as an "instrumented frame" behind the EMCal.  The basic design is tilted (tapered) plates of steel interleaved with scintillating tiles. 
![ECCE_iHCAL_frame](https://user-images.githubusercontent.com/3042746/122440120-e1ae3580-cf61-11eb-8cb7-894848f6bbbf.png)
The attached screen image shows and end-on view of the cryostat (outer/coil/inner) and the new iHCAL snugged up against it. The straight lines for the enclosing volume are an artifact of how G4 draws the enclosing volume as straight tangents. This has been checked for overlaps (none found). 

Tanja, Friederike and I discussed the radial ranges for this - in this round we fix the outer radius of the EMCal at 134cm, which fixes the inner radius of the inner HCAL. The outer radius of the frame is fixed at 138.5 cm to respect the 2.5 cm keep-clear from the cryostat. Note that this is 4.5cm of frame, but sketchup has 7cm.  Clearly the frame requirements needs to be revisited and will be done after a meeting with the engineers next week. 

