### PR TITLE
Adding a surrogate for the DIRC prism

### DIFF
--- a/common/G4_DIRC.C
+++ b/common/G4_DIRC.C
@@ -3,8 +3,10 @@
 
 #include <GlobalVariables.C>
 
+#include <g4detectors/PHG4ConeSubsystem.h>
 #include <g4detectors/PHG4CylinderSubsystem.h>
 #include <g4detectors/PHG4SectorSubsystem.h>
+
 #include <g4trackfastsim/PHG4TrackFastSim.h>
 
 #include <g4main/PHG4Reco.h>
@@ -29,29 +31,30 @@ namespace Enable
 
 namespace G4DIRC
 {
-// Grzegorz Kalicy <gkalicy@jlab.org>
-// -position in z around IP -168 cm  to 287 cm
-// -69cm radius for the barrel (70cm inner radius for the bars)
-// -12 bar boxes, 10 long bars side-by-side in a bar box
-// -bar length  425cm
-// -Solid fused silica prism: 24 x 36 x 30 cm3 (H x W x L)
-// -Additional longitudinal space for MCP-PMTs, readout cards, cables: ~13cm
-// -radial thickness 7-8 cm, including mechanical support
-// -~16-18% of a radiation length at normal incidence
+  // Grzegorz Kalicy <gkalicy@jlab.org>
+  // -position in z around IP -168 cm  to 287 cm
+  // -69cm radius for the barrel (70cm inner radius for the bars)
+  // -12 bar boxes, 10 long bars side-by-side in a bar box
+  // -bar length  425cm
+  // -Solid fused silica prism: 24 x 36 x 30 cm3 (H x W x L)
+  // -Additional longitudinal space for MCP-PMTs, readout cards, cables: ~13cm
+  // -radial thickness 7-8 cm, including mechanical support
+  // -~16-18% of a radiation length at normal incidence
 
   double radiator_R = 70;
+  double z_prism = 30;
   double z_end = +168;
-  double z_start = -287;
+  double z_start = -287 + z_prism;
   double length = z_end - z_start;
-  double z_shift = 0.5*(z_end + z_start);
+  double z_shift = 0.5 * (z_end + z_start);
   double outer_skin_radius = 78;
 }  // namespace G4DIRC
 
 void DIRCInit()
 {
   BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, G4DIRC::outer_skin_radius);
-  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4DIRC::z_start);
-  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4DIRC::z_end);
+  BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, G4DIRC::z_end);
+  BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, G4DIRC::z_start - G4DIRC::z_prism);
 }
 
 //! Babar DIRC (Without most of support structure)
@@ -84,12 +87,12 @@ double DIRCSetup(PHG4Reco *g4Reco)
   // Inner skin:
   cyl = new PHG4CylinderSubsystem("DIRC_CST_Inner_Skin", 10);
   cyl->set_double_param("radius", 69);
-  cyl->set_double_param("length", G4DIRC::length);
+  cyl->set_double_param("length", G4DIRC::length + G4DIRC::z_prism);
   cyl->set_string_param("material", "G4_Al");
   cyl->set_double_param("thickness", 0.127);
   cyl->set_double_param("place_x", 0.);
   cyl->set_double_param("place_y", 0.);
-  cyl->set_double_param("place_z", G4DIRC::z_shift);
+  cyl->set_double_param("place_z", G4DIRC::z_shift - G4DIRC::z_prism * 0.5);
   cyl->SetActive(0);
   cyl->SuperDetector("DIRC");
   cyl->OverlapCheck(OverlapCheck);
@@ -111,11 +114,24 @@ double DIRCSetup(PHG4Reco *g4Reco)
 
   g4Reco->registerSubsystem(cyl);
 
+  // simple approximation for DIRC prism
+  PHG4ConeSubsystem *cone = new PHG4ConeSubsystem("DIRC_Prism");
+  cone->set_color(0, 1, 0);
+  cone->SetR1(G4DIRC::radiator_R, G4DIRC::radiator_R + 20);
+  cone->SetR2(G4DIRC::radiator_R, G4DIRC::radiator_R + 2);
+  cone->SetZlength(0.5 * G4DIRC::z_prism);
+  cone->SetPlaceZ(G4DIRC::z_start - 0.5 * G4DIRC::z_prism);
+  cone->SetMaterial("Quartz");
+  cone->SetActive(0);
+  cone->SuperDetector("DIRC");
+  cone->OverlapCheck(OverlapCheck);
+  g4Reco->registerSubsystem(cone);
+
+  // track projection to DIRC reference radiator R
   if (TRACKING::FastKalmanFilter)
   {
-    TRACKING::FastKalmanFilter -> add_cylinder_state("DIRC", G4DIRC::radiator_R);
+    TRACKING::FastKalmanFilter->add_cylinder_state("DIRC", G4DIRC::radiator_R);
     TRACKING::ProjectionNames.insert("DIRC");
-
   }
   // Done
   return G4DIRC::outer_skin_radius;


### PR DESCRIPTION
Adding a simple cone representing the material of DIRC prism and its effect in hadronic shower between EEMC and EHCal

![ECCE-June2021_50](https://user-images.githubusercontent.com/7947083/123204045-4ba86c80-d485-11eb-89c4-8b2c53f93e9e.png)

![ECCE-June2021_52](https://user-images.githubusercontent.com/7947083/123204056-5105b700-d485-11eb-8dfb-ff006fa8cdc8.png)
