### PR TITLE
Enable storing the xsec in the event evaluator

### DIFF
--- a/common/G4_EventEvaluator.C
+++ b/common/G4_EventEvaluator.C
@@ -45,6 +45,8 @@ void Event_Eval(const std::string &filename)
     eval->set_do_CLUSTERS(true);
 
   eval->set_do_MCPARTICLES(true);
+  eval->set_do_HEPMC(true);
+  eval->set_do_store_event_level_info(true);
   se->registerSubsystem(eval);
 
   return;


### PR DESCRIPTION
After looking at the test production, I noticed that the event evaluator was missing the cross section and hepmc output. This enables the options to store both in the event evaluator. I can also update the default in the coresoftware, but this this seemed more direct.

NOTE: I'm not 100% sure this is actually enough for the xsec, as I don't see the cross section being read from the EICsmear file, but I don't have a setup to easily test this at the moment. So this seemed like a reasonable first step as I try to disentangle it further. I'm very much open to suggestions here, especially if I'm missing some obvious way to extract this info