### PR TITLE
Outer tracker adjustment for ECCE

### DIFF
--- a/common/G4_Micromegas.C
+++ b/common/G4_Micromegas.C
@@ -68,7 +68,7 @@ void Micromegas(PHG4Reco* g4Reco)
   auto mm = new PHG4MicromegasSubsystem("MICROMEGAS", mm_layer);
   mm->SetActive();
   mm->set_double_param("mm_length", 220);
-  mm->set_double_param("mm_radius", 82);
+//  mm->set_double_param("mm_radius", 82);
   g4Reco->registerSubsystem(mm);
 }
 

--- a/common/G4_TTL_EIC.C
+++ b/common/G4_TTL_EIC.C
@@ -16,7 +16,7 @@ R__LOAD_LIBRARY(libg4detectors.so)
 int make_forward_station(string name, PHG4Reco *g4Reco, double zpos, double Rmin,
                          double Rmax, double tSilicon);
 int make_barrel_layer(string name, PHG4Reco *g4Reco,
-                      double radius, double halflength, double tSilicon);
+                      double radius, double z_start, double z_end, double tSilicon);
 
 //-----------------------------------------------------------------------------------//
 namespace Enable
@@ -74,7 +74,7 @@ void CTTLSetup(PHG4Reco *g4Reco)
   const double mm = .1 * cm;
   const double um = 1e-3 * mm;
 
-  make_barrel_layer("CTTL_0", g4Reco, 83, 180, 85 * um);
+  make_barrel_layer("CTTL_0", g4Reco, 80, -250, 180, 85 * um);
 }
 
 //-----------------------------------------------------------------------------------//
@@ -146,7 +146,7 @@ int make_forward_station(string name, PHG4Reco *g4Reco,
 
 //-----------------------------------------------------------------------------------//
 int make_barrel_layer(string name, PHG4Reco *g4Reco,
-                      double radius, double halflength, double tSilicon)
+                      double radius, double z_start, double z_end, double tSilicon)
 {
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::TTL_OVERLAPCHECK;
   //---------------------------------
@@ -156,6 +156,9 @@ int make_barrel_layer(string name, PHG4Reco *g4Reco,
   const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
   const double mm = .1 * cm;
   const double um = 1e-3 * mm;
+
+  const double halflength = 0.5 * (z_end - z_start);
+  const double z_center = 0.5 * (z_end + z_start);
 
   string layerName[nSubLayer] = {"SiliconSensor", "Metalconnection", "HDI", "Cooling",
                                  "Support1", "Support_Gap", "Support2"};
@@ -177,6 +180,7 @@ int make_barrel_layer(string name, PHG4Reco *g4Reco,
     cyl->SuperDetector(name);
     cyl->set_double_param("radius", currRadius);
     cyl->set_double_param("length", 2.0 * halflength);
+    cyl->set_double_param("place_z", z_center);
     cyl->set_string_param("material", material[l]);
     cyl->set_double_param("thickness", thickness[l]);
     if (l == 0) cyl->SetActive();  //only the Silicon Sensor is active

--- a/common/G4_mRwell_EIC.C
+++ b/common/G4_mRwell_EIC.C
@@ -22,12 +22,17 @@ namespace Enable
 namespace RWELL
 {
   //All units specified in cm unless stated otherwise
+  //  const int n_layer = 2;  //tracker layers
+  //  //const double nom_radius[RWELL::n_layer] = {79.5,90.0}; //77 to not hit DIRC
+  //  //  const double nom_radius[RWELL::n_layer] = {78.67, 90.0};  //77 to not hit DIRC
+  //  const double nom_radius[RWELL::n_layer] = {69 - 1.6 - 2.6, 78.67};  //77 to not hit DIRC
+  //  const double nom_driftgap[RWELL::n_layer] = {0.4, 0.4};
+  //  const double nom_length[RWELL::n_layer] = {300.0, 300.0};
+
   const int n_layer = 1;  //tracker layers
-  //const double nom_radius[RWELL::n_layer] = {79.5,90.0}; //77 to not hit DIRC
-  //  const double nom_radius[RWELL::n_layer] = {78.67, 90.0};  //77 to not hit DIRC
-  const double nom_radius[RWELL::n_layer] = {69 - 1.6 - 2.6, 78.67};  //77 to not hit DIRC
-  const double nom_driftgap[RWELL::n_layer] = {0.4, 0.4};
-  const double nom_length[RWELL::n_layer] = {300.0, 300.0};
+  const double nom_radius[RWELL::n_layer] = {69 - 1.6 - 2.6};
+  const double nom_driftgap[RWELL::n_layer] = {0.4};
+  const double nom_length[RWELL::n_layer] = {300.0};
 }  //namespace RWELL
 
 void RWellInit(int verbosity = 0)

--- a/common/G4_mRwell_EIC.C
+++ b/common/G4_mRwell_EIC.C
@@ -22,7 +22,7 @@ namespace Enable
 namespace RWELL
 {
   //All units specified in cm unless stated otherwise
-  const int n_layer = 2;  //tracker layers
+  const int n_layer = 1;  //tracker layers
   //const double nom_radius[RWELL::n_layer] = {79.5,90.0}; //77 to not hit DIRC
   //  const double nom_radius[RWELL::n_layer] = {78.67, 90.0};  //77 to not hit DIRC
   const double nom_radius[RWELL::n_layer] = {69 - 1.6 - 2.6, 78.67};  //77 to not hit DIRC


### PR DESCRIPTION
Following the last Tracking-PID integration meeting, to remove the last layer of muRWELL and use the LGAD attached to DRIC outer support cylinder as the max level arm tracker. LGAD geometry is also adjusted to provide hermetic TOF coverage

This setup is proposed for the main sample production of the July simulation campaign, while we expect alternative tracker-PID configurations to be studied/optimized in standalone simulation runs by the detector groups. 

![ECCE-June2021_68](https://user-images.githubusercontent.com/7947083/124980755-c8e5ec80-e002-11eb-8623-c5b185f2a6d1.png)
![ECCE-June2021_67](https://user-images.githubusercontent.com/7947083/124980774-cd120a00-e002-11eb-9f82-d07aa73ed58b.png)
![ECCE-June2021_66](https://user-images.githubusercontent.com/7947083/124980784-cedbcd80-e002-11eb-9576-a739b761f0b7.png)
