### PR TITLE
Added new seeding method

### DIFF
--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -20,6 +20,8 @@
 
 #include <phool/recoConsts.h>
 
+#include <RooUnblindPrecision.h>
+
 R__LOAD_LIBRARY(libfun4all.so)
 
 int Fun4All_G4_EICDetector(
@@ -45,6 +47,18 @@ int Fun4All_G4_EICDetector(
   // if the RANDOMSEED flag is set its value is taken as initial seed
   // which will produce identical results so you can debug your code
   // rc->set_IntFlag("RANDOMSEED", 12345);
+
+  bool generate_seed = false;
+
+  if (generate_seed)
+  {
+    size_t findSlash = inputFile.find_last_of("/");
+    string inputFileName = inputFile.substr(findSlash + 1, inputFile.size());
+
+    RooRealVar dummyVal("dummy", "", 0);
+    RooUnblindPrecision blindVal("blindVal", "blindVal", inputFileName.c_str(), nEvents, skip+1, dummyVal, kFALSE);
+    rc->set_IntFlag("RANDOMSEED", abs(ceil(blindVal.getVal()*1e2)));
+  }
 
   //===============
   // Input options


### PR DESCRIPTION
I added a new method to generate the random seed which can be used in production. This should make our samples easily reproducible without needing to add many new lines and draw out the original seeds.

This method used RooUnblindPrecision which produces a random value based off a string and two numbers, effectively a 3D generation based off a Gaussian distribution. I use:

1. The input file name (the path is stripped so the generation should be identical at any production site)
2. The number of events to be generated is used as the mean of the Gaussian
3. The event starting number is used as the width

A few alterations applied:
* The event start number always has 1 added to it as our first event is numbered as 0. This avoid a zero-width
* The random number is returned as a double but our seed input is a 32-bit signed int. I use abs and ceil for the conversion (maybe abs is unneeded...)
* The string tends to set the precision. The returned value of the RooUnblindPrecision is multiplied by 100 to avoid cutting off this precision too badly