### PR TITLE
Adding multiple track fits, using a subset of trackers

### DIFF
--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -21,69 +21,82 @@ namespace Enable
 void BarrelInit()
 {
 }
-//-----------------------------------------------------------------------------------//
-void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
+
+void BarrelFastKalmanFilterConfig(PHG4TrackFastSim * kalman_filter)
 {
-
-  // import Geometry (lines 111 to 148 in https://github.com/eic/g4lblvtx/blob/master/macros/auxiliary_studies/simplified_geometry/Fun4All_G4_simplified_v2.C):
-  PHG4CylinderSubsystem * cyl(nullptr);
-
-  //---------------------------
-  // Vertexing
-  double si_vtx_r_pos[] = {3.30,5.70,8.10};
-  const int nVtxLayers = sizeof(si_vtx_r_pos)/sizeof(*si_vtx_r_pos);
-  for (int ilayer = 0; ilayer < nVtxLayers ; ilayer++){
-  cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
-  cyl->set_string_param("material" , "G4_Si" );
-  cyl->set_double_param("radius" , si_vtx_r_pos[ilayer] );
-  cyl->set_double_param("thickness", 0.05/100.*9.37 );
-  cyl->set_double_param("place_z" , 0 );
-  cyl->set_double_param("length" , 30.);
-  cyl->SetActive();
-  cyl->SuperDetector("SVTX");
-  g4Reco->registerSubsystem(cyl);
-  }
-  //---------------------------
-  // Barrel
-  double si_r_pos[] = {21.,22.68};
-  const int nTrckLayers = sizeof(si_r_pos)/sizeof(*si_r_pos);
-  double si_z_length[] = {60.,60.};
-  for (int ilayer = 0; ilayer < nTrckLayers ; ilayer++){
-  cyl = new PHG4CylinderSubsystem("BARR", ilayer);
-  cyl->set_string_param("material" , "G4_Si" );
-  cyl->set_double_param("radius" , si_r_pos[ilayer] );
-  cyl->set_double_param("thickness", 0.05/100.*9.37 );
-  cyl->set_double_param("place_z" , 0 );
-  cyl->set_double_param("length" , si_z_length[ilayer]);
-  cyl->SetActive();
-  cyl->SuperDetector("BARR");
-  g4Reco->registerSubsystem(cyl);
-  }
 
   // import Kalman filter config (lines 226 to 246 here: https://github.com/eic/g4lblvtx/blob/master/macros/auxiliary_studies/simplified_geometry/Fun4All_G4_simplified_v2.C):
 
   // add Vertexing Layers
-  TRACKING::FastKalmanFilter->add_phg4hits(
-  "G4HIT_SVTX", // const std::string& phg4hitsNames,
-  PHG4TrackFastSim::Cylinder,
-  999., // radial-resolution [cm]
-  10./10000./sqrt(12.), // azimuthal-resolution [cm]
-  10./10000./sqrt(12.), // z-resolution [cm]
-  1, // efficiency,
-  0 // noise hits
+  kalman_filter->add_phg4hits(
+      "G4HIT_SVTX",  // const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,
+      999.,                      // radial-resolution [cm]
+      10. / 10000. / sqrt(12.),  // azimuthal-resolution [cm]
+      10. / 10000. / sqrt(12.),  // z-resolution [cm]
+      1,                         // efficiency,
+      0                          // noise hits
   );
 
   // add Barrel Layers
-  TRACKING::FastKalmanFilter->add_phg4hits(
-  "G4HIT_BARR", // const std::string& phg4hitsNames,
-  PHG4TrackFastSim::Cylinder,
-  999., // radial-resolution [cm]
-  10./10000./sqrt(12.), // azimuthal-resolution [cm]
-  10./10000./sqrt(12.), // z-resolution [cm]
-  1, // efficiency,
-  0 // noise hits
+  kalman_filter->add_phg4hits(
+      "G4HIT_BARR",  // const std::string& phg4hitsNames,
+      PHG4TrackFastSim::Cylinder,
+      999.,                      // radial-resolution [cm]
+      10. / 10000. / sqrt(12.),  // azimuthal-resolution [cm]
+      10. / 10000. / sqrt(12.),  // z-resolution [cm]
+      1,                         // efficiency,
+      0                          // noise hits
   );
 
+}
+
+
+//-----------------------------------------------------------------------------------//
+void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
+{
+  // import Geometry (lines 111 to 148 in https://github.com/eic/g4lblvtx/blob/master/macros/auxiliary_studies/simplified_geometry/Fun4All_G4_simplified_v2.C):
+  PHG4CylinderSubsystem *cyl(nullptr);
+
+  //---------------------------
+  // Vertexing
+  double si_vtx_r_pos[] = {3.30, 5.70, 8.10};
+  const int nVtxLayers = sizeof(si_vtx_r_pos) / sizeof(*si_vtx_r_pos);
+  for (int ilayer = 0; ilayer < nVtxLayers; ilayer++)
+  {
+    cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
+    cyl->set_string_param("material", "G4_Si");
+    cyl->set_double_param("radius", si_vtx_r_pos[ilayer]);
+    cyl->set_double_param("thickness", 0.05 / 100. * 9.37);
+    cyl->set_double_param("place_z", 0);
+    cyl->set_double_param("length", 30.);
+    cyl->SetActive();
+    cyl->SuperDetector("SVTX");
+    g4Reco->registerSubsystem(cyl);
+  }
+  //---------------------------
+  // Barrel
+  double si_r_pos[] = {21., 22.68};
+  const int nTrckLayers = sizeof(si_r_pos) / sizeof(*si_r_pos);
+  double si_z_length[] = {60., 60.};
+  for (int ilayer = 0; ilayer < nTrckLayers; ilayer++)
+  {
+    cyl = new PHG4CylinderSubsystem("BARR", ilayer);
+    cyl->set_string_param("material", "G4_Si");
+    cyl->set_double_param("radius", si_r_pos[ilayer]);
+    cyl->set_double_param("thickness", 0.05 / 100. * 9.37);
+    cyl->set_double_param("place_z", 0);
+    cyl->set_double_param("length", si_z_length[ilayer]);
+    cyl->SetActive();
+    cyl->SuperDetector("BARR");
+    g4Reco->registerSubsystem(cyl);
+  }
+
+  BarrelFastKalmanFilterConfig(TRACKING::FastKalmanFilter);
+
+  BarrelFastKalmanFilterConfig(TRACKING::FastKalmanFilterInnerTrack);
+
+  BarrelFastKalmanFilterConfig(TRACKING::FastKalmanFilterSiliconTrack);
 }
 
 #endif

--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -139,6 +139,20 @@ int make_LANL_FST_station(string name, PHG4Reco *g4Reco,
                                              50e-4 / sqrt(12.),                 //      const float lonres, *ignored in plane detector*
                                              1,                                 //      const float eff,
                                              0);                                //      const float noise
+    TRACKING::FastKalmanFilterInnerTrack->add_phg4hits(string("G4HIT_") + name,           //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                                             pitch / sqrt(12.),                 //      const float radres,
+                                             pitch / sqrt(12.),                 //      const float phires,
+                                             50e-4 / sqrt(12.),                 //      const float lonres, *ignored in plane detector*
+                                             1,                                 //      const float eff,
+                                             0);                                //      const float noise
+    TRACKING::FastKalmanFilterSiliconTrack->add_phg4hits(string("G4HIT_") + name,           //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                                             pitch / sqrt(12.),                 //      const float radres,
+                                             pitch / sqrt(12.),                 //      const float phires,
+                                             50e-4 / sqrt(12.),                 //      const float lonres, *ignored in plane detector*
+                                             1,                                 //      const float eff,
+                                             0);                                //      const float noise
   }
   return 0;
 }

--- a/common/G4_GEM_EIC.C
+++ b/common/G4_GEM_EIC.C
@@ -174,6 +174,15 @@ int make_GEM_station(string name, PHG4Reco *g4Reco, double zpos, double etamin,
                                              1,                                 //      const float eff,
                                              0);                                //      const float noise
 
+  if (TRACKING::FastKalmanFilterInnerTrack)
+    TRACKING::FastKalmanFilterInnerTrack->add_phg4hits(string("G4HIT_") + name,           //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                                             1. / sqrt(12.),                    //      const float radres,
+                                             70e-4,                             //      const float phires,
+                                             100e-4,                            //      const float lonres,
+                                             1,                                 //      const float eff,
+                                             0);                                //      const float noise
+
   return 0;
 }
 #endif

--- a/common/G4_TTL_EIC.C
+++ b/common/G4_TTL_EIC.C
@@ -44,7 +44,19 @@ namespace G4TTL
     int optionGeo   = 1;
     int optionGran  = 1;
   }  // namespace SETTING
-}  // namespace G4FHCAL
+
+
+
+  // 2, LGAD based ToF by Wei Li:
+  // Present the recent simulation studies and detector layout for the LGAD based ToF,
+  // which can be used as an outer tracker. The current detector can reach around 30 micron spatial
+  // resolution with 500 micron AC-LGAD sensor.
+  // This detector can provide better coverage and provide further constraints in track
+  // reconstruction within high pseudorapidity regions.
+
+  const double PositionResolution(30e-4);
+
+}  // namespace G4TTL
 
 
 //-----------------------------------------------------------------------------------//
@@ -192,6 +204,21 @@ int make_forward_station(string name, PHG4Reco *g4Reco,
   ttl->OverlapCheck(false);
   
   g4Reco->registerSubsystem(ttl);
+
+
+  if (TRACKING::FastKalmanFilter)
+  {
+    TRACKING::FastKalmanFilter->add_phg4hits(string("G4HIT_") + name,           //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                                             G4TTL::PositionResolution,           //      const float radres,
+                                             G4TTL::PositionResolution,           //      const float phires,
+                                             tSilicon / sqrt(12.),              //      const float lonres, *ignored in plane detector*
+                                             1,                                 //      const float eff,
+                                             0);                                //      const float noise
+    TRACKING::FastKalmanFilter->add_zplane_state(name, zpos);
+    TRACKING::ProjectionNames.insert(name);
+  }
+
   return 0;
 }
 
@@ -251,6 +278,20 @@ int make_forward_station_basic(string name, PHG4Reco *g4Reco,
   ttl->get_geometry().AddLayer("Support2", "G4_GRAPHITE", 50 * um, false, 100);
 
   g4Reco->registerSubsystem(ttl);
+
+
+  if (TRACKING::FastKalmanFilter)
+  {
+    TRACKING::FastKalmanFilter->add_phg4hits(string("G4HIT_") + name,           //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Vertical_Plane,  //      const DETECTOR_TYPE phg4dettype,
+                                             G4TTL::PositionResolution,           //      const float radres,
+                                             G4TTL::PositionResolution,           //      const float phires,
+                                             tSilicon / sqrt(12.),              //      const float lonres, *ignored in plane detector*
+                                             1,                                 //      const float eff,
+                                             0);                                //      const float noise
+    TRACKING::FastKalmanFilter->add_zplane_state(name, zpos);
+    TRACKING::ProjectionNames.insert(name);
+  }
   return 0;
 }
 
@@ -274,6 +315,22 @@ int make_barrel_layer(string name, PHG4Reco *g4Reco,
   ttl->OverlapCheck(false);
 
   g4Reco->registerSubsystem(ttl);
+
+
+  if (TRACKING::FastKalmanFilter)
+  {
+    TRACKING::FastKalmanFilter->add_phg4hits(string("G4HIT_") + name,     //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+                                             tSilicon / sqrt(12.),        //      const float radres,
+                                             G4TTL::PositionResolution,     //      const float phires,
+                                             G4TTL::PositionResolution,     //      const float lonres,
+                                             1,                           //      const float eff,
+                                             0);                          //      const float noise
+    TRACKING::FastKalmanFilter->add_cylinder_state(name, radius);
+
+    TRACKING::ProjectionNames.insert(name);
+  }
+
   return 0;
 }
 
@@ -319,6 +376,21 @@ int make_barrel_layer_basic(string name, PHG4Reco *g4Reco,
     g4Reco->registerSubsystem(cyl);
     currRadius = currRadius+thickness[l];
 //     cout << currRadius << endl;
+  }
+
+
+  if (TRACKING::FastKalmanFilter)
+  {
+    TRACKING::FastKalmanFilter->add_phg4hits(string("G4HIT_") + name,     //      const std::string& phg4hitsNames,
+                                             PHG4TrackFastSim::Cylinder,  //      const DETECTOR_TYPE phg4dettype,
+                                             tSilicon / sqrt(12.),        //      const float radres,
+                                             G4TTL::PositionResolution,     //      const float phires,
+                                             G4TTL::PositionResolution,     //      const float lonres,
+                                             1,                           //      const float eff,
+                                             0);                          //      const float noise
+    TRACKING::FastKalmanFilter->add_cylinder_state(name, radius);
+
+    TRACKING::ProjectionNames.insert(name);
   }
 
   return 0;

--- a/common/G4_mRwell_EIC.C
+++ b/common/G4_mRwell_EIC.C
@@ -379,6 +379,23 @@ double RWellSetup(PHG4Reco* g4Reco,
                                                55e-4,                                              //      const float lonres,
                                                1,                                                  //      const float eff,
                                                0);                                                 //      const float noise
+    if (TRACKING::FastKalmanFilterInnerTrack)
+      TRACKING::FastKalmanFilterInnerTrack->add_phg4hits(string("G4HIT_") + string(Form("RWELL_%d", ilyr)),  //      const std::string& phg4hitsNames,
+                                               PHG4TrackFastSim::Cylinder,                         //      const DETECTOR_TYPE phg4dettype,
+                                               1. / sqrt(12.),                                     //      const float radres,
+                                               55e-4,                                              //      const float phires,
+                                               55e-4,                                              //      const float lonres,
+                                               1,                                                  //      const float eff,
+                                               0);                                                 //      const float noise
+    // only for layers that is close to the silicon tracker system, use in FastKalmanFilterSiliconTrack
+    if (TRACKING::FastKalmanFilterSiliconTrack and RWELL::nom_radius[ilyr] < 50)
+      TRACKING::FastKalmanFilterSiliconTrack->add_phg4hits(string("G4HIT_") + string(Form("RWELL_%d", ilyr)),  //      const std::string& phg4hitsNames,
+                                               PHG4TrackFastSim::Cylinder,                         //      const DETECTOR_TYPE phg4dettype,
+                                               1. / sqrt(12.),                                     //      const float radres,
+                                               55e-4,                                              //      const float phires,
+                                               55e-4,                                              //      const float lonres,
+                                               1,                                                  //      const float eff,
+                                               0);                                                 //      const float noise
   }
   return radius;  //cm
 }

--- a/common/GlobalVariables.C
+++ b/common/GlobalVariables.C
@@ -64,6 +64,10 @@ namespace TRACKING
 
   PHG4TrackFastSim * FastKalmanFilter(nullptr);
 
+  PHG4TrackFastSim * FastKalmanFilterSiliconTrack(nullptr);
+
+  PHG4TrackFastSim * FastKalmanFilterInnerTrack(nullptr);
+
   std::set<std::string> ProjectionNames;
 }
 

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -36,7 +36,7 @@ int Fun4All_G4_EICDetector(
   // Fun4All server
   //---------------
   Fun4AllServer *se = Fun4AllServer::instance();
-  se->Verbosity(INT_MAX - 10);
+  se->Verbosity(0);
   //Opt to print all random seed used for debugging reproducibility. Comment out to reduce stdout prints.
   //PHRandomSeed::Verbosity(1);
 
@@ -279,7 +279,7 @@ int Fun4All_G4_EICDetector(
   Enable::RWELL = true;
   // barrel tracker
   Enable::TrackingService = true;
-  Enable::TrackingService_VERBOSITY = INT_MAX - 10;
+  // Enable::TrackingService_VERBOSITY = INT_MAX - 10;
   Enable::BARREL = true;
   // fst
   Enable::FST = true;


### PR DESCRIPTION
Per request of @FriederikeBock , adding options of inner track and silicon track

* silicon track uses silicon tracker and MPGD with R<50cm
* inner track uses all tracker other than those behind the RICH detectors, i.e. excluding TTLs

Behavior for the default track does not change. But a bug is fixed to add TTL in the Kalman fit

They show up in DST as 
```
      TRACKS (PHCompositeNode)/
         TrackMap (IO,SvtxTrackMap_v1)
         SvtxVertexMap (IO,SvtxVertexMap_v1)
         SiliconTrackMap (IO,SvtxTrackMap_v1)
         InnerTrackMap (IO,SvtxTrackMap_v1)
```