### PR TITLE
Reducing inner HCal thickness by 1cm

### DIFF
--- a/common/G4_HcalIn_ref.C
+++ b/common/G4_HcalIn_ref.C
@@ -131,7 +131,7 @@ double HCalInner(PHG4Reco *g4Reco,
 
   hcal->set_double_param("outer_radius", 138.5);
   hcal->set_double_param("scinti_outer_radius", 138.0);
-  hcal->set_double_param("inner_radius", 134.0);
+  hcal->set_double_param("inner_radius", 135.0);
   hcal->set_double_param("tilt_angle", 36.15);
   hcal->set_double_param("size_z", length);
   hcal->set_int_param("n_scinti_tiles", 0);


### PR DESCRIPTION
Following BCal update, https://github.com/eic/fun4all_eicdetectors/pull/53, Reducing inner HCal thickness by 1cm so everything fits