### PR TITLE
Adding simplified beam chamber according to the vacuum volume of the Aug-2021 IR model

### DIFF
--- a/common/G4_Pipe_EIC.C
+++ b/common/G4_Pipe_EIC.C
@@ -137,10 +137,9 @@ double Pipe(PHG4Reco* g4Reco,
     if (Enable::IP6)
     {
       PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
-      gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.v2.gdml");
+      gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "Beam/ConstructSimplifiedBeamChamber.gdml");
       gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
       gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
-      gdml->set_double_param("rot_z", 180); // flip crossing sign convension after July-2021
       gdml->OverlapCheck(OverlapCheck);
       g4Reco->registerSubsystem(gdml);
     }

--- a/common/G4_Pipe_EIC.C
+++ b/common/G4_Pipe_EIC.C
@@ -40,7 +40,7 @@ void PipeInit()
   if (G4PIPE::use_forward_pipes)
   {
     BlackHoleGeometry::max_radius = std::max(BlackHoleGeometry::max_radius, 23.);
-    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 450.);
+    BlackHoleGeometry::max_z = std::max(BlackHoleGeometry::max_z, 500.);
     BlackHoleGeometry::min_z = std::min(BlackHoleGeometry::min_z, -463.);
   }
   else
@@ -117,11 +117,9 @@ double Pipe(PHG4Reco* g4Reco,
   {
     if (Enable::IP6)
     {
-      PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardEnvelope");
-      gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/Detector_chamber_3-20-20.G4Import.v2.gdml");
-      gdml->set_string_param("TopVolName", "ElectronForwardEnvelope");
-      gdml->set_double_param("rot_z", 180); // flip crossing sign convension after July-2021
-      gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
+      PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("ElectronForwardChamber");
+      gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "/Beam/ConstructSimplifiedBeamChamber.gdml");
+      gdml->set_string_param("TopVolName", "ElectronForwardChamber");
       gdml->OverlapCheck(OverlapCheck);
       g4Reco->registerSubsystem(gdml);
     }
@@ -139,7 +137,6 @@ double Pipe(PHG4Reco* g4Reco,
       PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardChamber");
       gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "Beam/ConstructSimplifiedBeamChamber.gdml");
       gdml->set_string_param("TopVolName", "HadronForwardChamber");
-      gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
       gdml->OverlapCheck(OverlapCheck);
       g4Reco->registerSubsystem(gdml);
     }

--- a/common/G4_Pipe_EIC.C
+++ b/common/G4_Pipe_EIC.C
@@ -136,9 +136,9 @@ double Pipe(PHG4Reco* g4Reco,
   {
     if (Enable::IP6)
     {
-      PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardEnvelope");
+      PHG4GDMLSubsystem* gdml = new PHG4GDMLSubsystem("HadronForwardChamber");
       gdml->set_string_param("GDMPath", string(getenv("CALIBRATIONROOT")) + "Beam/ConstructSimplifiedBeamChamber.gdml");
-      gdml->set_string_param("TopVolName", "HadronForwardEnvelope");
+      gdml->set_string_param("TopVolName", "HadronForwardChamber");
       gdml->set_int_param("skip_DST_geometry_export", 1);  // do not export extended beam pipe as it is not supported by TGeo and outside Kalman filter acceptance
       gdml->OverlapCheck(OverlapCheck);
       g4Reco->registerSubsystem(gdml);

--- a/common/G4_hFarBwdBeamLine_EIC.C
+++ b/common/G4_hFarBwdBeamLine_EIC.C
@@ -40,7 +40,7 @@ namespace Enable
 
 namespace hFarBwdBeamLine
 {
-  double starting_z = -410;  //cm as center-forward interface
+  double starting_z = -463;  //cm clear the backward beam chamber
   double enclosure_z_max = NAN;
   double enclosure_r_max = NAN;
   double enclosure_center = NAN;

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -264,7 +264,7 @@ int Fun4All_G4_EICDetector(
   // whether to simulate the Be section of the beam pipe
   Enable::PIPE = true;
   // If need to disable EIC beam pipe extension beyond the Be-section:
-  G4PIPE::use_forward_pipes = false;
+  G4PIPE::use_forward_pipes = true;
   //EIC hadron far forward magnets and detectors. IP6 and IP8 are incompatible (pick either or);
   Enable::HFARFWD_MAGNETS = true;
   Enable::HFARFWD_VIRTUAL_DETECTORS = true;


### PR DESCRIPTION
Following https://github.com/ECCE-EIC/calibrations/pull/8, and add the simplified beam chamber according to the vacuum volume of the Aug-2021 IR model. 

Aug-2021 model extend the hadron beam pipe to +5m. The previous chamber envelop is removed, which resolve the overlap with forward TTL and calorimeters. 

Display of 18x275GeV beam simulation with the detector setup: 
![July-Concept31](https://user-images.githubusercontent.com/7947083/133733692-0414dee9-e7a8-4011-a2d7-f9ee3f253e58.png)

![July-Concept33](https://user-images.githubusercontent.com/7947083/133733778-44bffc23-2719-4bb1-bf16-7aab9273bae1.png)



![July-Concept32](https://user-images.githubusercontent.com/7947083/133733698-ada256cc-eb62-4311-a6fd-0a5c1408ddb9.png)

![July-Concept24](https://user-images.githubusercontent.com/7947083/133733719-a5c38e0a-4837-419c-9f22-45e7f1865496.png)


