### PR TITLE
Fix dRICH beam opening

### DIFF
--- a/common/G4_dRICH.C
+++ b/common/G4_dRICH.C
@@ -45,7 +45,7 @@ void RICHSetup(PHG4Reco* g4Reco)
   double dz = 100; //Length of dRICH
 
   EICG4dRICHSubsystem *drichSubsys = new EICG4dRICHSubsystem("dRICh");
-  drichSubsys->SetGeometryFile(string(getenv("CALIBRATIONROOT")) + "/dRICH/mapping/drich-g4model_v2.txt");
+  drichSubsys->SetGeometryFile(string(getenv("CALIBRATIONROOT")) + "/dRICH/mapping/drich-g4model_v3.txt");
   drichSubsys->set_double_param("place_z", z + dz*0.5);// relative position to mother vol.
   drichSubsys->OverlapCheck(OverlapCheck);
   drichSubsys->Verbosity(verbosity);


### PR DESCRIPTION
Following #66 , https://github.com/ECCE-EIC/calibrations/pull/9 and https://github.com/ECCE-EIC/calibrations/pull/10 , use the updated dRICH with beam opening clear the EIC hadron beam chamber. 

Thanks to Sebastian Araya for his immediate response! 
![July-Concept39](https://user-images.githubusercontent.com/7947083/133860710-e1a04bbc-4a61-442a-ad7e-c6f553280055.png)
![July-Concept38](https://user-images.githubusercontent.com/7947083/133860712-1146aabe-dc0a-4577-a7c4-2d5d9590fa89.png)

