### PR TITLE
Incorporate fast PID into the reconstruction workflow

### DIFF
--- a/common/G4_DSTReader_EICDetector.C
+++ b/common/G4_DSTReader_EICDetector.C
@@ -51,15 +51,6 @@ void G4DSTreader_EICDetector(const string &outputFile = "G4sPHENIXCells.root")
     {
       ana->AddNode("PIPE");
     }
-    if (Enable::BARREL)
-    {
-      int nBarrel=6;
-      for (int i = 10; i < 10+nBarrel; i++)
-	{
-	  ana->AddNode(Form("LBLVTX_CENTRAL_%d", i));
-	}
-    }
-
     if (Enable::EGEM)
     {
       ana->AddNode("EGEM_0");
@@ -159,7 +150,7 @@ void G4DSTreader_EICDetector(const string &outputFile = "G4sPHENIXCells.root")
 //    }
     if (Enable::DIRC)
     {
-      ana->AddNode("DIRC");
+      ana->AddNode("hpDIRC");
     }
     if (Enable::RICH)
     {
@@ -168,6 +159,7 @@ void G4DSTreader_EICDetector(const string &outputFile = "G4sPHENIXCells.root")
     if (Enable::mRICH)
     {
       ana->AddNode("mRICH");
+      ana->AddNode("ABSORBER_mRICH");
     }
 
     if (Enable::BLACKHOLE)

--- a/common/G4_EventEvaluator.C
+++ b/common/G4_EventEvaluator.C
@@ -34,6 +34,8 @@ void Event_Eval(const std::string &filename)
     eval->set_do_PROJECTIONS(true);
     if (G4TRACKING::DISPLACED_VERTEX)
       eval->set_do_VERTEX(true);
+    if (Enable::DIRC_RECO or Enable::mRICH_RECO or Enable::RICH_RECO)
+      eval->set_do_PID_LogLikelihood(true);
   }
   if (Enable::CEMC_CLUSTER) eval->set_do_CEMC(true);
   if (Enable::EEMC_CLUSTER) eval->set_do_EEMC(true);

--- a/common/G4_dRICH.C
+++ b/common/G4_dRICH.C
@@ -10,6 +10,8 @@
 
 #include <GlobalVariables.C>
 
+#include <eccefastpidreco/ECCEFastPIDReco.h>
+#include <eccefastpidreco/ECCEdRICHFastPIDMap.h>
 #include <g4drich/EICG4dRICHSubsystem.h>
 #include <g4trackfastsim/PHG4TrackFastSim.h>
 
@@ -18,9 +20,12 @@
 R__LOAD_LIBRARY(libg4detectors.so)
 R__LOAD_LIBRARY(libEICG4dRICH.so)
 
+R__LOAD_LIBRARY(libECCEFastPIDReco.so)
+
 namespace Enable
 {
   bool RICH = false;
+  bool RICH_RECO = false;
   bool RICH_OVERLAPCHECK = false;
   int RICH_VERBOSITY = 0;
 }  // namespace Enable
@@ -36,17 +41,17 @@ void RICHInit()
 //- it starts 180 cm from IP
 //- radius of aerogel part starts at 110 cm at rises up to 120cm over 20 cm of length.
 //- at 175 cm from IP it rapidly grows radially to radius 210cm at stays constant like a cylinder until end at 280cm from the IP
-void RICHSetup(PHG4Reco* g4Reco)
+void RICHSetup(PHG4Reco *g4Reco)
 {
   bool OverlapCheck = Enable::OVERLAPCHECK || Enable::RICH_OVERLAPCHECK;
   int verbosity = std::max(Enable::VERBOSITY, Enable::RICH_VERBOSITY);
 
-  double z = 185; //Start of dRICH
-  double dz = 100; //Length of dRICH
+  double z = 185;   //Start of dRICH
+  double dz = 100;  //Length of dRICH
 
   EICG4dRICHSubsystem *drichSubsys = new EICG4dRICHSubsystem("dRICh");
   drichSubsys->SetGeometryFile(string(getenv("CALIBRATIONROOT")) + "/dRICH/mapping/drich-g4model_v3.txt");
-  drichSubsys->set_double_param("place_z", z + dz*0.5);// relative position to mother vol.
+  drichSubsys->set_double_param("place_z", z + dz * 0.5);  // relative position to mother vol.
   drichSubsys->OverlapCheck(OverlapCheck);
   drichSubsys->Verbosity(verbosity);
   drichSubsys->SetActive();
@@ -56,9 +61,33 @@ void RICHSetup(PHG4Reco* g4Reco)
   if (TRACKING::FastKalmanFilter)
   {
     // project to an reference plane at z=170 cm
-    TRACKING::FastKalmanFilter-> add_zplane_state("RICH", 185);
+    TRACKING::FastKalmanFilter->add_zplane_state("RICH", 185);
     TRACKING::ProjectionNames.insert("RICH");
   }
-
 }
+
+void RICHReco()
+{
+  const int verbosity = std::max(Enable::VERBOSITY, Enable::RICH_VERBOSITY);
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ECCEdRICHFastPIDMap *pidmap = new ECCEdRICHFastPIDMap();
+  pidmap->Verbosity(verbosity);
+  pidmap->dualRICH_aerogel();
+
+  ECCEFastPIDReco *reco = new ECCEFastPIDReco(pidmap, EICPIDDefs::dRICH_AeroGel, "ECCEFastPIDReco-dRICH_AeroGel");
+  reco->Verbosity(verbosity);
+
+  se->registerSubsystem(reco);
+
+  pidmap = new ECCEdRICHFastPIDMap();
+  pidmap->Verbosity(verbosity);
+  pidmap->dualRICH_C2F6();
+
+  reco = new ECCEFastPIDReco(pidmap, EICPIDDefs::dRICH_Gas, "ECCEFastPIDReco-dRICH_Gas");
+  reco->Verbosity(verbosity);
+
+  se->registerSubsystem(reco);
+}
+
 #endif

--- a/common/G4_mRICH.C
+++ b/common/G4_mRICH.C
@@ -6,7 +6,8 @@
 
 #include <g4mrich/PHG4mRICHSubsystem.h>
 #include <g4trackfastsim/PHG4TrackFastSim.h>
-//#include <g4rich/PHG4mRICHSubsystem.h>
+#include <eccefastpidreco/ECCEFastPIDReco.h>
+#include <eccefastpidreco/ECCEmRICHFastPIDMap.h>
 /*!
  * \file G4_mRICH.C
  * \brief Aerogel mRICH for EIC detector
@@ -14,10 +15,14 @@
  * \date $Date: 2020/7/2  $
  */
 
+R__LOAD_LIBRARY(libECCEFastPIDReco.so)
+
 namespace Enable
 {
   bool mRICH = false;
+  bool mRICH_RECO = false;
   bool mRICH_OVERLAPCHECK = false;
+  int mRICH_VERBOSITY = 0;
 }  // namespace Enable
 
 void mRICHInit()
@@ -52,9 +57,26 @@ void mRICHSetup(PHG4Reco *g4Reco, const int detectorSetup = 1,  //1: full setup;
   if (TRACKING::FastKalmanFilter)
   {
     // project to an reference plane at z=170 cm
-    TRACKING::FastKalmanFilter-> add_zplane_state("mRICH", -170);
+    TRACKING::FastKalmanFilter-> add_zplane_state("mRICH", -125);
     TRACKING::ProjectionNames.insert("mRICH");
   }
+}
+
+
+void mRICHReco(int verbosity = 0)
+{
+  verbosity = std::max(Enable::VERBOSITY, verbosity);
+  verbosity = std::max(Enable::mRICH_VERBOSITY, verbosity);
+
+  Fun4AllServer *se = Fun4AllServer::instance();
+
+  ECCEmRICHFastPIDMap * pidmap = new ECCEmRICHFastPIDMap();
+  pidmap->Verbosity(verbosity);
+
+  ECCEFastPIDReco * reco = new ECCEFastPIDReco(pidmap, EICPIDDefs::mRICH, "ECCEFastPIDReco-mRICH");
+  reco->Verbosity(verbosity);
+
+  se->registerSubsystem(reco);
 }
 
 void mRICH_Eval(std::string outputfile, int verbosity = 0)

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -328,12 +328,18 @@ int Fun4All_G4_EICDetector(
 
   // EICDetector geometry - barrel
   Enable::DIRC = true;
+  Enable::DIRC_RECO = Enable::DIRC && true;
+  // Enable::DIRC_VERBOSITY = 2;
 
   // EICDetector geometry - 'hadron' direction
   Enable::RICH = true;
+  Enable::RICH_RECO = Enable::DIRC && true;
+  // Enable::RICH_VERBOSITY = 2;
 
   // EICDetector geometry - 'electron' direction
   Enable::mRICH = true;
+  Enable::mRICH_RECO = Enable::DIRC && true;
+  // Enable::mRICH_VERBOSITY = 2;
 
   Enable::FEMC = true;
   //  Enable::FEMC_ABSORBER = true;
@@ -488,10 +494,16 @@ int Fun4All_G4_EICDetector(
   if (Enable::DSTOUT_COMPRESS) ShowerCompress();
 
   //--------------
-  // SVTX tracking
+  // Tracking and PID
   //--------------
 
   if (Enable::TRACKING) Tracking_Reco();
+
+  if (Enable::DIRC_RECO) DIRCReco();
+
+  if (Enable::mRICH_RECO ) mRICHReco();
+
+  if (Enable::RICH_RECO) RICHReco();
 
   //-----------------
   // Global Vertexing


### PR DESCRIPTION
Import the [fast PID parameterization](https://github.com/ECCE-EIC/ecce-detectors/blob/master/FastPID/) provided by PID group and incorporate it into the simulation-reconstruction workflow. 

* PID infrastructure: https://github.com/eic/fun4all_eicdetectors/pull/61
* Fast PID reconstruction module: https://github.com/ECCE-EIC/ecce-detectors/pull/1 
* Database entry: https://github.com/ECCE-EIC/calibrations/pull/11 
* Tutorial on how to use the PID object: https://github.com/ECCE-EIC/tutorials/pull/4 

High level PID summary is also added to the event eval output attached to the track information. 