### PR TITLE
necessary changes for correct hit association and TTL geometry setup

### DIFF
--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -22,14 +22,15 @@ void BarrelInit()
 {
 }
 
-void BarrelFastKalmanFilterConfig(PHG4TrackFastSim * kalman_filter)
+
+void BarrelFastKalmanFilterConfigSVTX(PHG4TrackFastSim * kalman_filter, int ilay, double radius, bool addproj)
 {
 
   // import Kalman filter config (lines 226 to 246 here: https://github.com/eic/g4lblvtx/blob/master/macros/auxiliary_studies/simplified_geometry/Fun4All_G4_simplified_v2.C):
 
   // add Vertexing Layers
   kalman_filter->add_phg4hits(
-      "G4HIT_SVTX",  // const std::string& phg4hitsNames,
+      Form("G4HIT_SVTX_%d",ilay),  // const std::string& phg4hitsNames,
       PHG4TrackFastSim::Cylinder,
       999.,                      // radial-resolution [cm]
       10. / 10000. / sqrt(12.),  // azimuthal-resolution [cm]
@@ -37,10 +38,15 @@ void BarrelFastKalmanFilterConfig(PHG4TrackFastSim * kalman_filter)
       1,                         // efficiency,
       0                          // noise hits
   );
+  kalman_filter->add_cylinder_state(Form("SVTX_%d",ilay), radius);
+  if(addproj)TRACKING::ProjectionNames.insert(Form("SVTX_%d",ilay));
+}
 
+void BarrelFastKalmanFilterConfigBARR(PHG4TrackFastSim * kalman_filter, int ilay, double radius, bool addproj)
+{
   // add Barrel Layers
   kalman_filter->add_phg4hits(
-      "G4HIT_BARR",  // const std::string& phg4hitsNames,
+      Form("G4HIT_BARR_%d",ilay),  // const std::string& phg4hitsNames,
       PHG4TrackFastSim::Cylinder,
       999.,                      // radial-resolution [cm]
       10. / 10000. / sqrt(12.),  // azimuthal-resolution [cm]
@@ -48,6 +54,8 @@ void BarrelFastKalmanFilterConfig(PHG4TrackFastSim * kalman_filter)
       1,                         // efficiency,
       0                          // noise hits
   );
+  kalman_filter->add_cylinder_state(Form("BARR_%d",ilay), radius);
+  if(addproj)TRACKING::ProjectionNames.insert(Form("BARR_%d",ilay));
 
 }
 
@@ -64,15 +72,19 @@ void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
   const int nVtxLayers = sizeof(si_vtx_r_pos) / sizeof(*si_vtx_r_pos);
   for (int ilayer = 0; ilayer < nVtxLayers; ilayer++)
   {
-    cyl = new PHG4CylinderSubsystem("SVTX", ilayer);
+    cyl = new PHG4CylinderSubsystem(Form("SVTX_%d",ilayer), ilayer);
     cyl->set_string_param("material", "G4_Si");
     cyl->set_double_param("radius", si_vtx_r_pos[ilayer]);
     cyl->set_double_param("thickness", 0.05 / 100. * 9.37);
     cyl->set_double_param("place_z", 0);
     cyl->set_double_param("length", 30.);
     cyl->SetActive();
-    cyl->SuperDetector("SVTX");
+    cyl->SuperDetector(Form("SVTX_%d",ilayer));
     g4Reco->registerSubsystem(cyl);
+
+    BarrelFastKalmanFilterConfigSVTX(TRACKING::FastKalmanFilter, ilayer, si_vtx_r_pos[ilayer],true);
+    BarrelFastKalmanFilterConfigSVTX(TRACKING::FastKalmanFilterInnerTrack, ilayer, si_vtx_r_pos[ilayer],false);
+    BarrelFastKalmanFilterConfigSVTX(TRACKING::FastKalmanFilterSiliconTrack, ilayer, si_vtx_r_pos[ilayer],false);
   }
   //---------------------------
   // Barrel
@@ -81,22 +93,21 @@ void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
   double si_z_length[] = {60., 60.};
   for (int ilayer = 0; ilayer < nTrckLayers; ilayer++)
   {
-    cyl = new PHG4CylinderSubsystem("BARR", ilayer);
+    cyl = new PHG4CylinderSubsystem(Form("BARR_%d",ilayer), ilayer);
     cyl->set_string_param("material", "G4_Si");
     cyl->set_double_param("radius", si_r_pos[ilayer]);
     cyl->set_double_param("thickness", 0.05 / 100. * 9.37);
     cyl->set_double_param("place_z", 0);
     cyl->set_double_param("length", si_z_length[ilayer]);
     cyl->SetActive();
-    cyl->SuperDetector("BARR");
+    cyl->SuperDetector(Form("BARR_%d",ilayer));
     g4Reco->registerSubsystem(cyl);
+
+    BarrelFastKalmanFilterConfigBARR(TRACKING::FastKalmanFilter, ilayer, si_r_pos[ilayer],true);
+    BarrelFastKalmanFilterConfigBARR(TRACKING::FastKalmanFilterInnerTrack, ilayer, si_r_pos[ilayer],false);
+    BarrelFastKalmanFilterConfigBARR(TRACKING::FastKalmanFilterSiliconTrack, ilayer, si_r_pos[ilayer],false);
   }
 
-  BarrelFastKalmanFilterConfig(TRACKING::FastKalmanFilter);
-
-  BarrelFastKalmanFilterConfig(TRACKING::FastKalmanFilterInnerTrack);
-
-  BarrelFastKalmanFilterConfig(TRACKING::FastKalmanFilterSiliconTrack);
 }
 
 #endif

--- a/common/G4_EventEvaluator.C
+++ b/common/G4_EventEvaluator.C
@@ -32,7 +32,7 @@ void Event_Eval(const std::string &filename)
   if (Enable::TRACKING)
   {
     eval->set_do_TRACKS(true);
-    //eval->set_do_HITS(true);
+    eval->set_do_HITS(true);
     eval->set_do_PROJECTIONS(true);
     if (G4TRACKING::DISPLACED_VERTEX)
       eval->set_do_VERTEX(true);

--- a/common/G4_TTL_EIC.C
+++ b/common/G4_TTL_EIC.C
@@ -35,6 +35,8 @@ namespace G4TTL
   double positionToVtx[3][3]    = { {-169., -172., -309.5}, {80., 114.7, 0. }, { 287., 289., 340.} };
   double minExtension[3][3]     = { {8, 8, 15.3}, {218, 180, 0 }, {11.62, 11.7, 13.8 } };
   double maxExtension[3][3]     = { {61., 61. , 200}, {-40, 0, 0 }, {170., 170., 250  } };
+  double xoffsetFTTLIP6[3]         = { -6., -6., -6.};
+  double xoffsetFTTLIP8[3]      = { 8.4, 8.4, 8.4};
   namespace SETTING
   {
     bool optionCEMC  = true;
@@ -84,13 +86,15 @@ void TTL_Init()
 
   if (G4TTL::SETTING::optionGeo == 1){
     cout << "TTL setup infront of ECals with 2 layers fwd/bwd & 1 layer barrel" << endl;  
-  } if (G4TTL::SETTING::optionGeo == 2){
+  }
+  if (G4TTL::SETTING::optionGeo == 2){
     cout << "TTL setup infront of ECals with 2 layers fwd/bwd & 1 layer barrel, lower barrel layer" << endl;  
     G4TTL::positionToVtx[1][0] = 50.;
     if(!G4TTL::SETTING::optionBasicGeo) G4TTL::positionToVtx[1][0] = 65.;
     G4TTL::minExtension[1][0]  = 100.;
     G4TTL::maxExtension[1][0]  = 0.;
-  } if (G4TTL::SETTING::optionGeo == 3){
+  }
+  if (G4TTL::SETTING::optionGeo == 3 || G4TTL::SETTING::optionGeo == 5 || G4TTL::SETTING::optionGeo == 6){
     cout << "TTL setup infront of ECals with 1 layers fwd/bwd & 1 layer barrel, lower barrel layer" << endl;  
     G4TTL::positionToVtx[1][0] = 50.;
     if(!G4TTL::SETTING::optionBasicGeo) G4TTL::positionToVtx[1][0] = 65.;
@@ -104,12 +108,40 @@ void TTL_Init()
     G4TTL::minExtension[2][0]  = G4TTL::minExtension[2][1];
     G4TTL::maxExtension[0][0]  = G4TTL::maxExtension[0][1];
     G4TTL::maxExtension[2][0]  = G4TTL::maxExtension[2][1];
-  } if (G4TTL::SETTING::optionGeo == 4){
+  }
+  if (G4TTL::SETTING::optionGeo == 4){
     cout << "TTL setup infront of ECals  with 2 layers fwd/bwd & 1 layer barrel, 1 layer before HCals everywhere" << endl;  
     G4TTL::layer[0]    = 3;
     G4TTL::layer[1]    = 2;
     if(!G4TTL::SETTING::optionBasicGeo) G4TTL::layer[1]    = 1;
     G4TTL::layer[2]    = 3;
+  }
+  if(G4TTL::SETTING::optionGeo == 7){
+    cout << "TTL one forward disk in front of dRICH and one backward disk in front of EEMC, barrel CTTL center at radius 64cm" << endl;
+    // single disk in front of dRICH (full eta)
+    G4TTL::layer[2]            = 1;
+    G4TTL::minExtension[2][0] = 7.0;
+    G4TTL::maxExtension[2][0] = 87;
+    G4TTL::positionToVtx[2][0] = 182.;
+    G4TTL::xoffsetFTTLIP6[0] = -2.7;
+    G4TTL::xoffsetFTTLIP8[0] = 3.0;
+
+    // single disk in front of EEMC
+    G4TTL::layer[0]            = 1;
+    // G4TTL::minExtension[0][0] = 7.0;
+    // G4TTL::maxExtension[0][0] = 87;
+    // G4TTL::positionToVtx[0][0] = 182.;
+    // G4TTL::xoffsetFTTLIP6[0] = -2.7;
+    // G4TTL::xoffsetFTTLIP8[0] = 3.0;
+
+    // barrel layer at 64cm
+    G4TTL::positionToVtx[1][0] = 64.;
+    G4TTL::minExtension[1][0] = 140;
+    G4TTL::maxExtension[1][0] = 0;
+  }
+  if(G4TTL::SETTING::optionGeo == 8){
+    cout << "TTL forward disk 1 reduced in radius to 60cm" << endl;
+    G4TTL::maxExtension[2][0] = 60.;
   }
 
   if (G4TTL::SETTING::optionDR == 2 && G4TTL::SETTING::optionGeo == 4 ){
@@ -130,14 +162,10 @@ void FTTLSetup(PHG4Reco *g4Reco, TString fttloption = "")
   const double mm = .1 * cm;
   const double um = 1e-3 * mm;
 
-  double xoffset = 0;
-  if (Enable::IP6) xoffset = -6.0;
-  if (Enable::IP8) xoffset = 8.4;
-
   for (Int_t i = 0; i < G4TTL::layer[2]; i++){
     cout << G4TTL::positionToVtx[2][i] << "\t" << G4TTL::minExtension[2][i] << "\t" << G4TTL::maxExtension[2][i] << endl;
     if(!G4TTL::SETTING::optionBasicGeo){
-      make_forward_station(Form("FTTL_%d", i), g4Reco, G4TTL::positionToVtx[2][i],  G4TTL::minExtension[2][i], G4TTL::maxExtension[2][i], 85*um, xoffset);
+      make_forward_station(Form("FTTL_%d", i), g4Reco, G4TTL::positionToVtx[2][i],  G4TTL::minExtension[2][i], G4TTL::maxExtension[2][i], 85*um, Enable::IP8 ? G4TTL::xoffsetFTTLIP8[i] : G4TTL::xoffsetFTTLIP6[i]);
     } else {
       make_forward_station_basic(Form("FTTL_%d", i), g4Reco, G4TTL::positionToVtx[2][i],  G4TTL::minExtension[2][i], G4TTL::maxExtension[2][i], 85*um);
     }
@@ -204,7 +232,7 @@ int make_forward_station(string name, PHG4Reco *g4Reco,
   ttl->set_double_param("rMax", rMax * cm);                    //
   ttl->set_double_param("offset_x", xoffset * cm);                    //
   ttl->set_double_param("tSilicon", tSilicon);                    //
-//   ttl->OverlapCheck(true);
+  // ttl->OverlapCheck(true);
   ttl->OverlapCheck(Enable::OVERLAPCHECK);
   
   g4Reco->registerSubsystem(ttl);
@@ -266,7 +294,7 @@ int make_forward_station_basic(string name, PHG4Reco *g4Reco,
   ttl->get_geometry().set_min_polar_edge(PHG4Sector::Sector_Geometry::ConeEdge());
   ttl->get_geometry().set_N_Sector(1);
   ttl->get_geometry().set_material("G4_AIR");
-  ttl->OverlapCheck(true);
+  ttl->OverlapCheck(Enable::OVERLAPCHECK);
   
   const double cm = PHG4Sector::Sector_Geometry::Unit_cm();
   const double mm = .1 * cm;

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -274,7 +274,7 @@ int Fun4All_G4_EICDetector(
 
   // gems
   Enable::EGEM = true;
-  Enable::FGEM = true;
+  // Enable::FGEM = true; // deactivated as it's replaced by a FTTL layer
   // Enable::BGEM = true; // not yet defined in this model
   Enable::RWELL = true;
   // barrel tracker
@@ -289,7 +289,7 @@ int Fun4All_G4_EICDetector(
   Enable::ETTL = true;
   Enable::CTTL = true;
   G4TTL::SETTING::optionCEMC = false;
-  G4TTL::SETTING::optionGeo = 1;
+  G4TTL::SETTING::optionGeo = 7;
 
   Enable::TRACKING = true;
   Enable::TRACKING_EVAL = Enable::TRACKING && true;


### PR DESCRIPTION
This PR should be checked by people using the SVTX and BARR hits outside of the EventEvaluator, since the hits are now correctly labelled _1, _2, ... for the different layers. Otherwise these hits must be associated from their x,y,z position to their respective layers, which can lead to mistakes.

In addition, the TTL geometry setting 7 is introduced, which is the now final setup for ECCE with one forward disk in front of dRICH and one backward disk in front of EEMC. In addition, with a barrel CTTL that is located at a radius of ~64cm.