### PR TITLE
Implement the silicon design as in the cost model

### DIFF
--- a/common/G4_Barrel_EIC.C
+++ b/common/G4_Barrel_EIC.C
@@ -69,7 +69,7 @@ void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
 
   //---------------------------
   // Vertexing
-  double si_vtx_r_pos[] = {3.40, 5.67, 7.93};
+  double si_vtx_r_pos[] = {3.3, 5.7, 8.1};
   const int nVtxLayers = sizeof(si_vtx_r_pos) / sizeof(*si_vtx_r_pos);
   for (int ilayer = 0; ilayer < nVtxLayers; ilayer++)
   {
@@ -78,7 +78,7 @@ void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
     cyl->set_double_param("radius", si_vtx_r_pos[ilayer]);
     cyl->set_double_param("thickness", 0.05 / 100. * 9.37);
     cyl->set_double_param("place_z", 0.);
-    cyl->set_double_param("length", 30.);
+    cyl->set_double_param("length", 27);
     cyl->SetActive();
 //    cyl->SuperDetector("SVTX");  breakout SVTX into individual layers
     cyl->OverlapCheck(OverlapCheck);
@@ -91,11 +91,11 @@ void Barrel(PHG4Reco *g4Reco, int det_ver = 3)
   //---------------------------
   // Barrel
 
-  double si_len = 60.0;
-  double z_e_length[] = {30., 30.};
-  double z_h_length[] = {30., 30.};
+  double si_len = 54;
+  double z_e_length[] = {-27, 27.};
+  double z_h_length[] = {-27., 27.};
   double si_z_length[] = {si_len, si_len};
-  double si_r_pos[] = {15.3, 17.0}; // Modified on 29th Oct to account for new struture design
+  double si_r_pos[] = {21, 22.68}; // Modified on 29th Oct to account for new struture design
   const int nTrckLayers = sizeof(si_r_pos) / sizeof(*si_r_pos);
   
   for (int ilayer = 0; ilayer < nTrckLayers; ilayer++)

--- a/common/G4_FST_EIC.C
+++ b/common/G4_FST_EIC.C
@@ -69,9 +69,12 @@ void FSTSetup(PHG4Reco *g4Reco)
 
 
 
-  const double bkwd_z[] = {33.2, 58.29, 80.05, 107.4};
-  double bkwd_rmin[] = {3.3, 3.3, 5.25, 6.4};
-  double bkwd_rmax[] = {15.3, 27.3, 35.25, 48.4};
+//  const double bkwd_z[] = {33.2, 58.29, 80.05, 107.4};
+//  double bkwd_rmin[] = {3.3, 3.3, 5.25, 6.4};
+//  double bkwd_rmax[] = {15.3, 27.3, 35.25, 48.4};
+  const double bkwd_z[] = {25, 52, 79, 106};
+  double bkwd_rmin[] = {3.5, 3.5, 4.5, 5.5};
+  double bkwd_rmax[] = {18.5, 36.5, 40.5, 41.5};
   const int n_bkwd_disk = sizeof(bkwd_z) / sizeof(*bkwd_z);
   for (unsigned int i = 0; i < n_bkwd_disk; i++)
   {
@@ -89,9 +92,9 @@ void FSTSetup(PHG4Reco *g4Reco)
   }
 
 
-  const double fwd_z[] = {33.2, 58.29, 79.85, 115, 125};
-  double fwd_rmin[] = {3.3, 3.3, 5.2, 6.5, 7.5};
-  double fwd_rmax[] = {15.3, 27.3, 35.2, 49.5, 49.5};
+  const double fwd_z[] = {25, 49,73, 106, 125};
+  double fwd_rmin[] = {3.5, 3.5, 4.5, 5.5, 7.5};
+  double fwd_rmax[] = {18.5, 36.5, 40.5, 41.5, 43.5};
   const int n_fwd_disk = sizeof(fwd_z) / sizeof(*fwd_z);
   for (unsigned int i = 0; i < n_fwd_disk; i++)
   {


### PR DESCRIPTION
Following tracking meeting, https://indico.bnl.gov/event/13508/, implement the tracker design as used in the costing model. 

The integrated detector with projective support cone is placed in a new branch: https://github.com/ECCE-EIC/macros/tree/AI_Optimization_October_2021_Concept , which will be maintained in parallel

## TODO 
1. will need to adjust the muRwell layers 1-2 based on the July-Concept and fit into this design. 
2. introduce a new support-service structure that consists of two projective section connected by one cylinder, e.g. the yellow line on the e-going side: 
![image](https://user-images.githubusercontent.com/7947083/140621936-615f0217-ac01-43b7-b0fb-60e6ffd989e4.png)


## Reference geometry for si tracker

From Xuan's description: 

            vertex layers: 
                  layer 1, r = 3.3 cm, z1 = -13.5cm, z2 = 13.5 cm
                  layer 2, r = 5.7 cm, z1 = -13.5cm, z2 = 13.5 cm
                  layer 3, r = 8.1 cm, z1 = -13.5cm, z2 = 13.5 cm

            middle layers:
                   layer 4, r = 21 cm, z1 = -27cm, z2 = 27cm
                   layer 5, r = 22.68 cm, z1 = -27cm, z2 = 27cm

            Hadron disks:
                   disk 1, Rmin = 3.5 cm, Rmax = 18.5cm, z = 25 cm
                   disk 2, Rmin = 3.5 cm, Rmax = 36.5cm, z = 49 cm
                   disk 3, Rmin = 4.5 cm, Rmax = 40.5cm, z = 73 cm
                   disk 4, Rmin = 5.5 cm, Rmax = 41.5 cm, z = 106 cm
                   disk 4, Rmin = 7.5 cm,  Rmax = 43.5 cm, z = 125 cm
        
            Electron disks:
                   disk 1, Rmin = 3.5 cm, Rmax = 18.5cm, z = -25 cm
                   disk 2, Rmin = 3.5 cm, Rmax = 36.5cm, z = -52 cm
                   disk 3, Rmin = 4.5 cm, Rmax = 40.5cm, z = -79 cm
                   disk 4, Rmin = 5.5 cm, Rmax = 41.5 cm, z = -106 cm
