### PR TITLE
Install default option for TTL to TTL macro

### DIFF
--- a/common/G4_TTL_EIC.C
+++ b/common/G4_TTL_EIC.C
@@ -39,11 +39,11 @@ namespace G4TTL
   double xoffsetFTTLIP8[3]      = { 8.4, 8.4, 8.4};
   namespace SETTING
   {
-    bool optionCEMC  = true;
+    bool optionCEMC  = false;
     bool optionEEMCH = true;
     bool optionBasicGeo    = false;
     int optionDR    = 0;
-    int optionGeo   = 1;
+    int optionGeo   = 7;
     int optionGran  = 1;
   }  // namespace SETTING
 

--- a/detectors/EICDetector/Fun4All_G4_EICDetector.C
+++ b/detectors/EICDetector/Fun4All_G4_EICDetector.C
@@ -288,8 +288,6 @@ int Fun4All_G4_EICDetector(
   Enable::FTTL = true;
   Enable::ETTL = true;
   Enable::CTTL = true;
-  G4TTL::SETTING::optionCEMC = false;
-  G4TTL::SETTING::optionGeo = 7;
 
   //mRPC TOFs
   Enable::BTOF = false;
@@ -364,7 +362,6 @@ int Fun4All_G4_EICDetector(
   Enable::DRCALO_TOWER = Enable::DRCALO_CELL && true;
   Enable::DRCALO_CLUSTER = Enable::DRCALO_TOWER && true;
   Enable::DRCALO_EVAL = Enable::DRCALO_CLUSTER && false;
-  G4TTL::SETTING::optionDR = 1;
 
   Enable::LFHCAL = true;
   Enable::LFHCAL_ABSORBER = false;
@@ -378,7 +375,6 @@ int Fun4All_G4_EICDetector(
   Enable::EEMCH_TOWER = Enable::EEMCH && true;
   Enable::EEMCH_CLUSTER = Enable::EEMCH_TOWER && true;
   Enable::EEMCH_EVAL = Enable::EEMCH_CLUSTER && true;
-  G4TTL::SETTING::optionEEMCH = Enable::EEMCH && true;
 
   Enable::EHCAL = true;
   Enable::EHCAL_CELL = Enable::EHCAL && true;


### PR DESCRIPTION
Install default option for TTL to TTL macro, so less error prone when turn on/off other subsystems and changes TTL accidentally, e.g. during material scan and AI optimization. 