### PR TITLE
Temp fix the tower geometry for EEMC

### DIFF
--- a/common/G4_EEMC_hybrid.C
+++ b/common/G4_EEMC_hybrid.C
@@ -181,7 +181,7 @@ void EEMCH_Towers()
   } else if (G4EEMCH::SETTING::USECUSTOMMAPCARBON){
     mapping_eemc_1 << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystal_mapping/tower_map_purecrystal_185cm_EEEMCcarbon.txt";
   } else if (G4EEMCH::SETTING::USECUSTOMMAPUPDATED){
-    mapping_eemc_1 << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystal_mapping/tower_map_purecrystal_185cm_updatedGeo.txt";
+    mapping_eemc_1 << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystal_mapping/tower_map_purecrystal_185cm_updatedGeo_TemporaryTowerFix.txt";
   } else if (G4EEMCH::SETTING::USEHYBRID && !G4EEMCH::SETTING::USECEMCGeo)
     mapping_eemc_1 << getenv("CALIBRATIONROOT") << "/CrystalCalorimeter/mapping/crystal_mapping/tower_map_crystal_200cm_SciGlassBarrel.txt";
   else if (G4EEMCH::SETTING::USEHYBRID && G4EEMCH::SETTING::USECEMCGeo)


### PR DESCRIPTION
Following https://github.com/ECCE-EIC/calibrations/pull/23: Temp fix for CrystalCalorimeter/mapping/crystal_mapping/tower_map_purecrystal_185cm_updatedGeo.txt to fix the tower geometry for EEMC

In early Dec, we had a fix on EEMC and this geometry file is used by default: 
https://github.com/ECCE-EIC/calibrations/blob/main/CrystalCalorimeter/mapping/crystal_mapping/tower_map_purecrystal_185cm_updatedGeo.txt  
On the line for Gz0, which is global detector location, this geometry file used Gz0=-185 cm, while other geometry file (tower_map_purecrystal_185cm.txt, tower_map_purecrystal_185cm_EEEMCcarbon.txt) used Gz0=0 cm. On top of that, the each tower location which is supposedly in local coordinate system was placed at also z=-185 cm. Translate tower from local coordinate to global coordinate, the tower geometry was placed at about -3.7m, also as attached: 
https://ecce-eic.github.io/doxygen/d4/d29/RawTowerBuilderByHitIndex_8cc_source.html#l00338 

Nonetheless, the actual location of EEMC blocks in G4 are correct, suggest the EEMCH G4 code ignored one of the two geometry shift. 

**Implication:** in the Dec prop.6 production for anyone originating from the ECCE software repo (central production, Bill, John): 
* The EEMC geometry in G4 is correct
* The EEMC tower geometry in reconstruction is shifted by -185cm ending at wrong location of -4m or so. 
* Track projection is to the same wrong z following towers. 

**What do we go from here?** 
1.	If your analysis do not call tower geometry or track projection from DST, everything seems fine 
2.	If your analysis do call tower geometry or track projection from DST, we can do a manual quick-dirty fix of subtracting +185cm in z. 
3.	For production team, we need to fix this, tag as prop.7 and rerun all sample

The quickest approach appears introducing a temporary copy of tower_map_purecrystal_185cm_updatedGeo.txt setting Gz0->0 cm, say tower_map_purecrystal_185cm_updatedGeo_tower.txt. Then use this new file for tower reconstruction (RawTowerBuilderByHitIndex) while leaving the G4 using the current geometry file. This introduced in this PR
